### PR TITLE
Tobias Zawada added recipe for TeXfrag

### DIFF
--- a/recipes/TeXfrag
+++ b/recipes/TeXfrag
@@ -1,0 +1,1 @@
+(TeXfrag :repo "TobiasZawada/TeXfrag" :fetcher github)


### PR DESCRIPTION
TeXfrag makes AUCTeX preview available for non-LaTeX modes (e.g., formulas in doxygen comments)

TeXfrag can be used together with sx-question-mode
sx-question-mode is on melpa. Therefore, TeXfrag should also be on melpa.
See: https://github.com/vermiculus/sx.el/issues/331

### Brief summary of what the package does

TeXfrag makes AUCTeX preview available for non-LaTeX modes
Examples:
 - formulas in doxygen comments
 - Render MathJax formulas in html pages (in source and in eww)
 - render formulas in stackexchange pages shown with the help of the [sx](https://github.com/vermiculus/sx.el) package

### Direct link to the package repository

https://github.com/TobiasZawada/TeXfrag

### Your association with the package

author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses). 
- [x] I've read [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.md](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.md)
